### PR TITLE
fix(PricingSlot): correct detection of header's highlight colour

### DIFF
--- a/src/PricingSlot.js
+++ b/src/PricingSlot.js
@@ -25,14 +25,6 @@ class PricingSlot extends React.Component {
         super(props);
     }
 
-    componentDidMount() {
-        this.props.highlighted
-            ? (document.getElementById(
-                  "highlighted-header"
-              ).style.backgroundColor = this.props.highlightColor)
-            : null;
-    }
-
     render() {
         const {
             highlighted,

--- a/src/PricingSlot.js
+++ b/src/PricingSlot.js
@@ -1,49 +1,80 @@
-import React from 'react';
-import Button from './Button';
-import PropTypes from 'prop-types';
+import React from "react";
+import Button from "./Button";
+import PropTypes from "prop-types";
 
 const propTypes = {
-  highlighted: PropTypes.bool,
-  onClick: PropTypes.func,
-  title: PropTypes.string,
-  priceText: PropTypes.string,
-  buttonClass:PropTypes.string,
-  buttonText: PropTypes.string,
-  children: PropTypes.node,
-  highlightColor: PropTypes.string,
-  shouldDisplayButton: PropTypes.bool
+    highlighted: PropTypes.bool,
+    onClick: PropTypes.func,
+    title: PropTypes.string,
+    priceText: PropTypes.string,
+    buttonClass: PropTypes.string,
+    buttonText: PropTypes.string,
+    children: PropTypes.node,
+    highlightColor: PropTypes.string,
+    shouldDisplayButton: PropTypes.bool
 };
 
 const defaultProps = {
-  highlighted: false,
-  highlightColor: "#f44336",
-  shouldDisplayButton: true
+    highlighted: false,
+    highlightColor: "#f44336",
+    shouldDisplayButton: true
 };
 
 class PricingSlot extends React.Component {
-  constructor(props) {
-    super(props);
-  }
+    constructor(props) {
+        super(props);
+    }
 
-  componentDidMount(){
-    this.props.highlighted ? document.getElementById("highlighted-header").style.backgroundColor=this.props.highlightColor : null;
-  }
+    componentDidMount() {
+        this.props.highlighted
+            ? (document.getElementById(
+                  "highlighted-header"
+              ).style.backgroundColor = this.props.highlightColor)
+            : null;
+    }
 
-  render() {
-    const {highlighted, highlightColor,buttonClass,buttonText, shouldDisplayButton} = this.props;
-    return (
-      <div className="Grid-cell">
-        <ul className="price basic-border">
-          <li id={(highlighted ? "highlighted" : "basic") + "-header"} className={(highlighted ? "highlighted" : "basic") + "-header"}>{this.props.title}</li>
-          <li className="tag">{this.props.priceText}</li>
-          {this.props.children}
-          {shouldDisplayButton && <li className="grey">
-            <Button onClick={this.props.onClick} color={highlightColor} className={buttonClass ? buttonClass : "button-submit"}>{buttonText}</Button>
-          </li>}
-        </ul>
-      </div>
-    )
-  }
+    render() {
+        const {
+            highlighted,
+            highlightColor,
+            buttonClass,
+            buttonText,
+            shouldDisplayButton
+        } = this.props;
+        return (
+            <div className="Grid-cell">
+                <ul className="price basic-border">
+                    <li
+                        style={
+                            highlighted
+                                ? { backgroundColor: highlightColor }
+                                : {}
+                        }
+                        className={
+                            (highlighted ? "highlighted" : "basic") + "-header"
+                        }
+                    >
+                        {this.props.title}
+                    </li>
+                    <li className="tag">{this.props.priceText}</li>
+                    {this.props.children}
+                    {shouldDisplayButton && (
+                        <li className="grey">
+                            <Button
+                                onClick={this.props.onClick}
+                                color={highlightColor}
+                                className={
+                                    buttonClass ? buttonClass : "button-submit"
+                                }
+                            >
+                                {buttonText}
+                            </Button>
+                        </li>
+                    )}
+                </ul>
+            </div>
+        );
+    }
 }
 
 PricingSlot.propTypes = propTypes;


### PR DESCRIPTION
Because it used to rely on an element's ID to apply highlight colour from the PricingSlot child, it caused bugs when multiple PricingTables where present on the same document. This commit fixes this behaviour by using a style object rather than using document.getElementByID which was causing the bug

**EDIT**: new PR because I messed up, this one is clean